### PR TITLE
Various exporting features

### DIFF
--- a/assets/i18n/en-US.json
+++ b/assets/i18n/en-US.json
@@ -123,7 +123,10 @@
     "SortieOptions": {
       "OpenReplayer": "Open Replayer",
       "OpenInReplayer": "Play in KanColle Battle Replayer",
-      "CopyToClipboard": "Copy Replay Data to Clipboard"
+      "CopyReplayToClipboard": "Copy Replay Data to Clipboard",
+      "ViewInDeckBuilder": "View in DeckBuilder",
+      "CopyDeckBuilderToClipboard": "Copy DeckBuilder Data to Clipboard",
+      "ViewInWctf": "View in WhoCallsTheFleet"
     }
   },
   "All": "All",

--- a/assets/i18n/en-US.json
+++ b/assets/i18n/en-US.json
@@ -114,6 +114,15 @@
     "SortMethod": {
       "recent": "Recent",
       "numeric": "Area"
+    },
+    "SortieTipsMD": [
+      "If \"Play in KanColle Battle Replayer\" does not work,",
+      "try copy to clipboard, paste your replay data into \"Load from text\" of",
+      "the replayer, and then hit \"Load\"."
+    ],
+    "SortieOptions": {
+      "OpenInReplayer": "Play in KanColle Battle Replayer",
+      "CopyToClipboard": "Copy Replay Data to Clipboard"
     }
   },
   "All": "All",

--- a/assets/i18n/en-US.json
+++ b/assets/i18n/en-US.json
@@ -121,6 +121,7 @@
       "the replayer, and then hit \"Load\"."
     ],
     "SortieOptions": {
+      "OpenReplayer": "Open Replayer",
       "OpenInReplayer": "Play in KanColle Battle Replayer",
       "CopyToClipboard": "Copy Replay Data to Clipboard"
     }

--- a/assets/i18n/ja-JP.json
+++ b/assets/i18n/ja-JP.json
@@ -114,6 +114,15 @@
     "SortMethod": {
       "recent": "新しい順番",
       "numeric": "マップ"
+    },
+    "SortieTipsMD": [
+      "If \"Play in KanColle Battle Replayer\" does not work,",
+      "try copy to clipboard, paste your replay data into \"Load from text\" of",
+      "the replayer, and then hit \"Load\"."
+    ],
+    "SortieOptions": {
+      "OpenInReplayer": "Play in KanColle Battle Replayer",
+      "CopyToClipboard": "Copy Replay Data to Clipboard"
     }
   },
   "All": "全て",

--- a/assets/i18n/ja-JP.json
+++ b/assets/i18n/ja-JP.json
@@ -121,6 +121,7 @@
       "the replayer, and then hit \"Load\"."
     ],
     "SortieOptions": {
+      "OpenReplayer": "Open Replayer",
       "OpenInReplayer": "Play in KanColle Battle Replayer",
       "CopyToClipboard": "Copy Replay Data to Clipboard"
     }

--- a/assets/i18n/ja-JP.json
+++ b/assets/i18n/ja-JP.json
@@ -123,7 +123,10 @@
     "SortieOptions": {
       "OpenReplayer": "Open Replayer",
       "OpenInReplayer": "Play in KanColle Battle Replayer",
-      "CopyToClipboard": "Copy Replay Data to Clipboard"
+      "CopyReplayToClipboard": "Copy Replay Data to Clipboard",
+      "ViewInDeckBuilder": "View in DeckBuilder",
+      "CopyDeckBuilderToClipboard": "Copy DeckBuilder Data to Clipboard",
+      "ViewInWctf": "View in WhoCallsTheFleet"
     }
   },
   "All": "全て",

--- a/assets/i18n/zh-CN.json
+++ b/assets/i18n/zh-CN.json
@@ -122,8 +122,11 @@
     ],
     "SortieOptions": {
       "OpenReplayer": "战斗播放器",
-      "OpenInReplayer": "用 KC3战斗播放器 回放",
-      "CopyToClipboard": "复制回放数据到剪贴板"
+      "OpenInReplayer": "用“KC3战斗播放器”回放",
+      "CopyReplayToClipboard": "复制回放数据到剪贴板",
+      "ViewInDeckBuilder": "在DeckBuilder中查看",
+      "CopyDeckBuilderToClipboard": "复制DeckBuilder数据到剪贴板",
+      "ViewInWctf": "在“是谁呼叫舰队”中查看"
     }
   },
   "All": "全部",

--- a/assets/i18n/zh-CN.json
+++ b/assets/i18n/zh-CN.json
@@ -117,7 +117,7 @@
     },
     "SortieTipsMD": [
       "若“用 KC3战斗播放器 回放”不可用，",
-      "请尝试“复制回放数据到剪贴板”，将战斗数据粘贴进播放器的“Load from text”部分，",
+      "请尝试“复制回放数据到剪贴板”，将数据粘贴进播放器的“Load from text”部分，",
       "并点击“Load”。"
     ],
     "SortieOptions": {

--- a/assets/i18n/zh-CN.json
+++ b/assets/i18n/zh-CN.json
@@ -114,6 +114,15 @@
     "SortMethod": {
       "recent": "最近",
       "numeric": "海域"
+    },
+    "SortieTipsMD": [
+      "若“用 KC3战斗播放器 回放”不可用，",
+      "请尝试“复制回放数据到剪贴板”，将战斗数据粘贴进播放器的“Load from text”部分，",
+      "并点击“Load”。"
+    ],
+    "SortieOptions": {
+      "OpenInReplayer": "用 KC3战斗播放器 回放",
+      "CopyToClipboard": "复制回放数据到剪贴板"
     }
   },
   "All": "全部",

--- a/assets/i18n/zh-CN.json
+++ b/assets/i18n/zh-CN.json
@@ -121,6 +121,7 @@
       "并点击“Load”。"
     ],
     "SortieOptions": {
+      "OpenReplayer": "战斗播放器",
       "OpenInReplayer": "用 KC3战斗播放器 回放",
       "CopyToClipboard": "复制回放数据到剪贴板"
     }

--- a/assets/i18n/zh-TW.json
+++ b/assets/i18n/zh-TW.json
@@ -117,7 +117,7 @@
     },
     "SortieTipsMD": [
       "若“用 KC3戰鬥播放器 回放”不可用，",
-      "請嘗試“複製回放數據到剪貼板”，將戰鬥數據粘貼進播放器的“Load from text”部分，",
+      "請嘗試“複製回放數據到剪貼板”，將數據粘貼進播放器的“Load from text”部分，",
       "並點擊“Load”。"
     ],
     "SortieOptions": {

--- a/assets/i18n/zh-TW.json
+++ b/assets/i18n/zh-TW.json
@@ -121,6 +121,7 @@
       "並點擊“Load”。"
     ],
     "SortieOptions": {
+      "OpenReplayer": "戰鬥播放器",
       "OpenInReplayer": "用 KC3戰鬥播放器 回放",
       "CopyToClipboard": "複製回放數據到剪貼板"
     }

--- a/assets/i18n/zh-TW.json
+++ b/assets/i18n/zh-TW.json
@@ -122,8 +122,11 @@
     ],
     "SortieOptions": {
       "OpenReplayer": "戰鬥播放器",
-      "OpenInReplayer": "用 KC3戰鬥播放器 回放",
-      "CopyToClipboard": "複製回放數據到剪貼板"
+      "OpenInReplayer": "用“KC3戰鬥播放器”回放",
+      "CopyReplayToClipboard": "複製回放數據到剪貼板",
+      "ViewInDeckBuilder": "在DeckBuilder中查看",
+      "CopyDeckBuilderToClipboard": "複製DeckBuilder數據到剪貼板",
+      "ViewInWctf": "在“是誰呼叫艦隊”中查看"
     }
   },
   "All": "全部",

--- a/assets/i18n/zh-TW.json
+++ b/assets/i18n/zh-TW.json
@@ -114,6 +114,15 @@
     "SortMethod": {
       "recent": "最近",
       "numeric": "海域"
+    },
+    "SortieTipsMD": [
+      "若“用 KC3戰鬥播放器 回放”不可用，",
+      "請嘗試“複製回放數據到剪貼板”，將戰鬥數據粘貼進播放器的“Load from text”部分，",
+      "並點擊“Load”。"
+    ],
+    "SortieOptions": {
+      "OpenInReplayer": "用 KC3戰鬥播放器 回放",
+      "CopyToClipboard": "複製回放數據到剪貼板"
     }
   },
   "All": "全部",

--- a/assets/main.css
+++ b/assets/main.css
@@ -245,8 +245,8 @@ img.svg {
 /* Browse Area */
 #browse-area .tip {
   font-size: 80%;
-  margin-bottom: 1em;
 }
+
 table .btn,
 table .form-control {
   height: 20px;
@@ -305,7 +305,6 @@ table .form-control {
   height: 100%;
   display: flex;
   flex-direction: column;
-
   margin-top: .5em;
 }
 

--- a/assets/main.css
+++ b/assets/main.css
@@ -247,6 +247,11 @@ img.svg {
   font-size: 80%;
 }
 
+#browse-area .tip .markdown p {
+  margin-bottom: .4em;
+}
+
+
 table .btn,
 table .form-control {
   height: 20px;

--- a/assets/main.css
+++ b/assets/main.css
@@ -245,6 +245,7 @@ img.svg {
 /* Browse Area */
 #browse-area .tip {
   font-size: 80%;
+  margin-bottom: 1em;
 }
 table .btn,
 table .form-control {
@@ -304,6 +305,8 @@ table .form-control {
   height: 100%;
   display: flex;
   flex-direction: column;
+
+  margin-top: .5em;
 }
 
 #main-tabs > .tab-content > #main-tabs-pane-1 #browse-area > .browse-view {

--- a/lib/deck-builder.es
+++ b/lib/deck-builder.es
@@ -14,8 +14,6 @@ const convertToDeckBuilder = async sortieIndexes => {
     poiRecords.map(r => AppData.loadBattle(r.id, false))
   )
 
-  window.poiBattles = poiBattles
-
   const fstBattle = poiBattles[0]
 
   let poiFleets = []

--- a/lib/deck-builder.es
+++ b/lib/deck-builder.es
@@ -1,0 +1,120 @@
+import _ from 'lodash'
+import AppData from 'lib/appdata'
+
+const convertToDeckBuilder = async sortieIndexes => {
+  const {
+    indexes: poiRecords,
+  } = sortieIndexes
+
+  if (poiRecords.length === 0)
+    throw new Error('cannot convert an empty record')
+
+  // starting for this line poiRecords cannot be empty.
+  const poiBattles = await Promise.all(
+    poiRecords.map(r => AppData.loadBattle(r.id, false))
+  )
+
+  window.poiBattles = poiBattles
+
+  const fstBattle = poiBattles[0]
+
+  let poiFleets = []
+
+  // [0]
+  poiFleets.push(fstBattle.fleet.main)
+  // [1]
+  poiFleets.push(fstBattle.fleet.escort)
+
+  const normalSupportFleet = _.head(
+    poiBattles.filter(
+      // only normal supports
+      b => b.type === 'Normal'
+    ).map(
+      b => b.fleet.support
+    ).filter(xs =>
+      Array.isArray(xs) && xs.length > 0
+    )
+  )
+  // [2]
+  poiFleets.push(normalSupportFleet)
+
+  const bossSupportFleet = _.head(
+    poiBattles.filter(
+      // only boss support (should be <= 1)
+      b => b.type === 'Boss'
+    ).map(
+      b => b.fleet.support
+    ).filter(xs =>
+      Array.isArray(xs) && xs.length > 0
+    )
+  )
+  // [3]
+  poiFleets.push(bossSupportFleet)
+
+  // here we expect to at least have poiFleets[0] available,
+  // which is the main sortieing fleet.
+  if (poiFleets[0].length === 7) {
+    if (Array.isArray(poiFleets[1])) {
+      console.warn('striking force should not have escort fleet')
+    }
+    const [fMain, fEscort, fNSup,fBSup] = poiFleets
+    poiFleets = [fEscort, fNSup, fMain, fBSup]
+  }
+
+  const dFleetPairs = poiFleets.map((poiFleet, fleetInd) => {
+    if (!Array.isArray(poiFleet) || poiFleet.length === 0)
+      return [`f${fleetInd+1}`, {}]
+
+    const transformShipM = (ship, shipInd) => {
+      if (!ship)
+        return []
+
+      const items = {}
+
+      // map for effect.
+      _.map(ship.poi_slot, (item, itemInd) => {
+        if (!item)
+          return
+        const itemObj = {id: item.api_slotitem_id}
+        if (_.isInteger(item.api_level))
+          itemObj.rf = item.api_level
+        if (_.isInteger(item.api_alv))
+          itemObj.mas = item.api_alv
+
+        items[`i${itemInd+1}`] = itemObj
+      })
+
+      if (ship.poi_slot_ex) {
+        const item = ship.poi_slot_ex
+        const itemObj = {id: item.api_slotitem_id}
+        if (_.isInteger(item.api_level))
+          itemObj.rf = item.api_level
+        if (_.isInteger(item.api_alv))
+          itemObj.mas = item.api_alv
+        items.ix = itemObj
+      }
+
+      const shipObj = {
+        id: ship.api_ship_id,
+        lv: ship.api_lv,
+        luck: ship.api_lucky[0],
+        items,
+      }
+
+      return [[`s${shipInd+1}`, shipObj]]
+    }
+
+    const fleetObj = _.fromPairs(
+      _.flatMap(poiFleet, transformShipM)
+    )
+
+    return [`f${fleetInd+1}`, fleetObj]
+  })
+
+  return {
+    version: 4,
+    ..._.fromPairs(dFleetPairs),
+  }
+}
+
+export { convertToDeckBuilder }

--- a/lib/wctf.es
+++ b/lib/wctf.es
@@ -1,0 +1,124 @@
+import _ from 'lodash'
+import { mapIdToStr } from 'subtender/kc'
+import AppData from 'lib/appdata'
+
+const convertToWctf = async sortieIndexes => {
+  const {
+    indexes: poiRecords, mapId,
+  } = sortieIndexes
+
+  if (poiRecords.length === 0)
+    throw new Error('cannot convert an empty record')
+
+  // starting for this line poiRecords cannot be empty.
+  const poiBattles = await Promise.all(
+    poiRecords.map(r => AppData.loadBattle(r.id, false))
+  )
+
+  console.log(sortieIndexes, poiBattles)
+
+  const fstBattle = poiBattles[0]
+
+  let poiFleets = []
+
+  // [0]
+  poiFleets.push(fstBattle.fleet.main)
+  // [1]
+  poiFleets.push(fstBattle.fleet.escort)
+
+  const normalSupportFleet = _.head(
+    poiBattles.filter(
+      // only normal supports
+      b => b.type === 'Normal'
+    ).map(
+      b => b.fleet.support
+    ).filter(xs =>
+      Array.isArray(xs) && xs.length > 0
+    )
+  )
+  // [2]
+  poiFleets.push(normalSupportFleet)
+
+  const bossSupportFleet = _.head(
+    poiBattles.filter(
+      // only boss support (should be <= 1)
+      b => b.type === 'Boss'
+    ).map(
+      b => b.fleet.support
+    ).filter(xs =>
+      Array.isArray(xs) && xs.length > 0
+    )
+  )
+  // [3]
+  poiFleets.push(bossSupportFleet)
+
+  const wData = {}
+  const fstRecord = poiRecords[0]
+  if (mapId !== 'pvp') {
+    wData.name = `${fstRecord.desc} ${mapIdToStr(mapId)} (${fstRecord.time})`
+  } else {
+    wData.name = `${fstRecord.desc} (${fstRecord.time})`
+  }
+
+  const wFleetArr = poiFleets.map(poiFleetInp => {
+    if (!Array.isArray(poiFleetInp))
+      return []
+    const poiFleet = _.compact(poiFleetInp)
+
+    const convertShip = poiShip => {
+      const mstId = poiShip.api_ship_id
+      const level = poiShip.api_lv
+      const luck = poiShip.api_lucky[0]
+
+      const wEquipInfoArr =
+        [0,1,2,3,'ex'].map(ind => {
+          const e =
+            ind === 'ex' ? poiShip.poi_slot_ex : poiShip.poi_slot[ind]
+          if (!e)
+            return null
+          return {
+            mstId: e.api_slotitem_id,
+            imp: _.isInteger(e.api_level) ? e.api_level : null,
+            ace: _.isInteger(e.api_alv) ? e.api_alv : null,
+          }
+        })
+
+      return [
+        mstId,
+        [level,luck],
+        // Array of mstId
+        wEquipInfoArr.map(x => !x ? null : x.mstId),
+        // Array of imp
+        wEquipInfoArr.map(x => !x ? null : x.imp),
+        // Array of ace
+        wEquipInfoArr.map(x => !x ? null : x.ace),
+      ]
+    }
+    return poiFleet.map(convertShip)
+  })
+
+
+  const poiLbas = fstBattle.fleet.LBAC || []
+  wData.name_airfields = poiLbas.map(x => x.api_name)
+
+  const wAirbase = [1,2,3].map(sqId => {
+    const squadron = poiLbas[sqId-1]
+    if (!squadron || !Array.isArray(squadron.api_plane_info))
+      return []
+    const convertEquip = rawEquip => {
+      if (!rawEquip)
+        return []
+      const mstId = rawEquip.poi_slot.api_slotitem_id
+      const ace = rawEquip.poi_slot.api_alv
+      const imp = rawEquip.poi_slot.api_level
+      return [mstId, _.isInteger(ace) ? ace : 0, _.isInteger(imp) ? imp : 0]
+    }
+    return squadron.api_plane_info.map(convertEquip)
+  })
+
+  wData.data = [...wFleetArr, wAirbase]
+
+  return wData
+}
+
+export { convertToWctf }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "lz-string": "^1.4.4",
-    "subtender": "^0.12.2"
+    "subtender": "^0.12.4"
   },
   "devDependencies": {
     "babel-eslint": "^8.0.1",

--- a/views/browse-area/index.es
+++ b/views/browse-area/index.es
@@ -135,18 +135,6 @@ class BrowseAreaImpl extends Component {
     }
     return (
       <div id="browse-area">
-        <Panel>
-          <Grid>
-            <Row>
-              <Col xs={12} className='tip'>
-                <span>{__('Tip') + ': '}</span>
-                <span>{__('Tip.Akashic1.Part1')}</span>
-                <span><FontAwesome name='info-circle' /></span>
-                <span>{__('Tip.Akashic1.Part2')}</span>
-              </Col>
-            </Row>
-          </Grid>
-        </Panel>
         <Panel
           className="browse-view"
           header={
@@ -170,6 +158,16 @@ class BrowseAreaImpl extends Component {
             </div>
           }>
           <div style={browseMode === 'nodes' ? {} : {display: 'none'}}>
+            <Grid>
+              <Row>
+                <Col xs={12} className='tip'>
+                  <span>{__('Tip') + ': '}</span>
+                  <span>{__('Tip.Akashic1.Part1')}</span>
+                  <span><FontAwesome name='info-circle' /></span>
+                  <span>{__('Tip.Akashic1.Part2')}</span>
+                </Col>
+              </Row>
+            </Grid>
             <form onSubmit={this.onClickFilter}>
               <Table className="browse-table" striped bordered condensed hover fill>
                 <OverlayTrigger placement='top' overlay={

--- a/views/browse-area/index.es
+++ b/views/browse-area/index.es
@@ -160,7 +160,9 @@ class BrowseAreaImpl extends Component {
           <div style={browseMode === 'nodes' ? {} : {display: 'none'}}>
             <Grid>
               <Row>
-                <Col xs={12} className='tip'>
+                <Col
+                  style={{marginBottom: '1em'}}
+                  xs={12} className='tip'>
                   <span>{__('Tip') + ': '}</span>
                   <span>{__('Tip.Akashic1.Part1')}</span>
                   <span><FontAwesome name='info-circle' /></span>

--- a/views/browse-area/sortie-viewer/index.es
+++ b/views/browse-area/sortie-viewer/index.es
@@ -4,6 +4,7 @@ import { compressToEncodedURIComponent } from 'lz-string'
 import { createStructuredSelector } from 'reselect'
 import React, { PureComponent } from 'react'
 import { connect } from 'react-redux'
+import Markdown from 'react-remarkable'
 import {
   ListGroup, ListGroupItem,
   Pagination,
@@ -57,8 +58,6 @@ const rankColors = {
   'D': '#4caf50',
   'E': '#03a9f4',
 }
-
-// TODO: i18n
 
 class SortieViewerImpl extends PureComponent {
   static propTypes = {
@@ -143,186 +142,197 @@ class SortieViewerImpl extends PureComponent {
       fcdMap,
     } = this.props
     return (
-      <div style={{display: 'flex'}}>
-        <div
-          style={{
-            width: '20%',
-            minWidth: '10em',
-            marginRight: 5,
-            display: 'flex',
-            flexDirection: 'column',
-          }}
-        >
-          <ButtonGroup
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          flex: 1,
+        }}
+      >
+        <div className="tip">
+          <Markdown
+            source={_.join(__('BrowseArea.SortieTipsMD'), '\n')}
+          />
+        </div>
+        <div style={{display: 'flex'}}>
+          <div
             style={{
-              marginBottom: 5,
+              width: '20%',
+              minWidth: '10em',
+              marginRight: 5,
+              display: 'flex',
+              flexDirection: 'column',
             }}
           >
-            <Button
-              onClick={this.handleClickSortMethod('recent')}
-              bsStyle={
-                sortBy.method === 'recent' ?
-                  'primary' :
-                  'default'
-              }
-              style={{width: '50%'}}
+            <ButtonGroup
+              style={{
+                marginBottom: 5,
+              }}
             >
-              <span>
-                {__('BrowseArea.SortMethod.recent')}
-              </span>
-              {
-                sortBy.method === 'recent' && (
-                  <FontAwesome
-                    style={{marginLeft: '.2em'}}
-                    name={sortBy.reversed ? 'sort-desc' : 'sort-asc'}
-                  />
-                )
-              }
-            </Button>
-            <Button
-              onClick={this.handleClickSortMethod('numeric')}
-              bsStyle={
-                sortBy.method === 'numeric' ?
-                  'primary' :
-                  'default'
-              }
-              style={{width: '50%'}}
-            >
-              <span>
-                {__('BrowseArea.SortMethod.numeric')}
-              </span>
-              {
-                sortBy.method === 'numeric' && (
-                  <FontAwesome
-                    style={{marginLeft: '.2em'}}
-                    name={
-                      /*
-                         intentionally reversed than 'recent'
-                         as it looks more natural to have numeric values ascending
-                       */
-                      sortBy.reversed ? 'sort-asc' : 'sort-desc'
-                    }
-                  />
-                )
-              }
-            </Button>
-          </ButtonGroup>
-          <ListGroup
-            style={{
-              overflowY: 'auto',
-              flex: 1,
-            }}>
-            {
-              mapIds.map(curMapId => (
-                <ListGroupItem
-                  key={curMapId}
-                  onClick={this.handleMapIdChange(curMapId)}
-                  style={{padding: '5px 10px'}}
-                  fill>
-                  <div className={curMapId === mapId ? 'text-primary' : ''}>
-                    {pprMapId(curMapId)}
-                  </div>
-                </ListGroupItem>
-              ))
-            }
-          </ListGroup>
-        </div>
-        <div
-          style={{flex: 1, display: 'flex', flexDirection: 'column'}}
-        >
-          <ListGroup style={{flex: 1, overflowY: 'auto'}}>
-            {
-              focusingSortieIndexes.map(si => {
-                const firstIndex = si.indexes[0]
-                const routes = _.get(fcdMap,[firstIndex.map,'route'])
-                const compId = firstIndex.id
-                const desc =
-                  si.mapId === 'pvp' ? firstIndex.desc :
-                    `${__('Sortie')} ${pprMapId(si.mapId)}`
-                const timeDesc =
-                  si.indexes.length === 1 ? firstIndex.time :
-                    `${firstIndex.time} ~ ${_.last(si.indexes).time}`
-                return (
-                  <ListGroupItem
-                    key={compId}
-                    style={{padding: '5px 10px', display: 'flex'}}>
-                    <div style={{flex: 1}}>
-                      <div style={{display: 'flex'}}>
-                        <div
-                          style={{
-                            flex: 1,
-                            fontWeight: 'bold',
-                            fontSize: '110%',
-                          }}>{desc}</div>
-                        <div>{timeDesc}</div>
-                      </div>
-                      <div style={{display: 'flex', flexWrap: 'wrap'}}>
-                        {
-                          si.indexes.map(index => (
-                            <Button
-                              bsSize="xsmall"
-                              style={{
-                                marginRight: '.4em', width: '3.6em',
-                              }}
-                              onClick={this.handleSelectBattle(index)}
-                              key={index.id}>
-                              <div style={{
-                                fontWeight: 'bold',
-                                ...(index.rank in rankColors ? {color: rankColors[index.rank]} : {}),
-                              }}>
-                                {
-                                  index.map === '' ? 'PvP' :
-                                    (_.isEmpty(routes) ? index.route_ : routes[index.route_][1])
-                                }
-                              </div>
-                            </Button>
-                          ))
-                        }
-                      </div>
-                    </div>
-                    <DropdownButton
-                      noCaret pullRight
-                      style={{
-                        width: '3em',
-                        height: '3em',
-                        marginLeft: '.4em',
-                        // this is to get the icon on center
-                        padding: 0,
-                      }}
-                      title={
-                        <FontAwesome name="bars" />
+              <Button
+                onClick={this.handleClickSortMethod('recent')}
+                bsStyle={
+                  sortBy.method === 'recent' ?
+                    'primary' :
+                    'default'
+                }
+                style={{width: '50%'}}
+              >
+                <span>
+                  {__('BrowseArea.SortMethod.recent')}
+                </span>
+                {
+                  sortBy.method === 'recent' && (
+                    <FontAwesome
+                      style={{marginLeft: '.2em'}}
+                      name={sortBy.reversed ? 'sort-desc' : 'sort-asc'}
+                    />
+                  )
+                }
+              </Button>
+              <Button
+                onClick={this.handleClickSortMethod('numeric')}
+                bsStyle={
+                  sortBy.method === 'numeric' ?
+                    'primary' :
+                    'default'
+                }
+                style={{width: '50%'}}
+              >
+                <span>
+                  {__('BrowseArea.SortMethod.numeric')}
+                </span>
+                {
+                  sortBy.method === 'numeric' && (
+                    <FontAwesome
+                      style={{marginLeft: '.2em'}}
+                      name={
+                        /*
+                           intentionally reversed than 'recent'
+                           as it looks more natural to have numeric values ascending
+                         */
+                        sortBy.reversed ? 'sort-asc' : 'sort-desc'
                       }
-                      id={`battle-detail-sortie-viewer-battle-${compId}`}
-                    >
-                      <MenuItem
-                        onClick={this.handleClickPlay(si)}
-                      >
-                        Play in KanColle Battle Replayer
-                      </MenuItem>
-                      <MenuItem
-                        onClick={this.handleCopyToClipboard(si)}
-                      >
-                        Copy Replay Data to Clipboard
-                      </MenuItem>
-                    </DropdownButton>
+                    />
+                  )
+                }
+              </Button>
+            </ButtonGroup>
+            <ListGroup
+              style={{
+                overflowY: 'auto',
+                flex: 1,
+              }}>
+              {
+                mapIds.map(curMapId => (
+                  <ListGroupItem
+                    key={curMapId}
+                    onClick={this.handleMapIdChange(curMapId)}
+                    style={{padding: '5px 10px'}}
+                    fill>
+                    <div className={curMapId === mapId ? 'text-primary' : ''}>
+                      {pprMapId(curMapId)}
+                    </div>
                   </ListGroupItem>
-                )
-              })
-            }
-          </ListGroup>
-          <Pagination
-            style={{marginBottom: '1em'}}
-            items={pageRange}
-            activePage={activePage}
-            prev
-            next
-            first
-            last
-            ellipsis
-            boundaryLinks
-            maxButtons={5}
-            onSelect={this.handleSelectPage}
-          />
+                ))
+              }
+            </ListGroup>
+          </div>
+          <div
+            style={{flex: 1, display: 'flex', flexDirection: 'column'}}
+          >
+            <ListGroup style={{flex: 1, overflowY: 'auto'}}>
+              {
+                focusingSortieIndexes.map(si => {
+                  const firstIndex = si.indexes[0]
+                  const routes = _.get(fcdMap,[firstIndex.map,'route'])
+                  const compId = firstIndex.id
+                  const desc =
+                    si.mapId === 'pvp' ? firstIndex.desc : `${__('Sortie')} ${pprMapId(si.mapId)}`
+                  const timeDesc =
+                    si.indexes.length === 1 ? firstIndex.time : `${firstIndex.time} ~ ${_.last(si.indexes).time}`
+                  return (
+                    <ListGroupItem
+                      key={compId}
+                      style={{padding: '5px 10px', display: 'flex'}}>
+                      <div style={{flex: 1}}>
+                        <div style={{display: 'flex'}}>
+                          <div
+                            style={{
+                              flex: 1,
+                              fontWeight: 'bold',
+                              fontSize: '110%',
+                            }}>{desc}</div>
+                          <div>{timeDesc}</div>
+                        </div>
+                        <div style={{display: 'flex', flexWrap: 'wrap'}}>
+                          {
+                            si.indexes.map(index => (
+                              <Button
+                                bsSize="xsmall"
+                                style={{
+                                  marginRight: '.4em', width: '3.6em',
+                                }}
+                                onClick={this.handleSelectBattle(index)}
+                                key={index.id}>
+                                <div style={{
+                                  fontWeight: 'bold',
+                                  ...(index.rank in rankColors ? {color: rankColors[index.rank]} : {}),
+                                }}>
+                                  {
+                                    index.map === '' ? 'PvP' :
+                                      (_.isEmpty(routes) ? index.route_ : routes[index.route_][1])
+                                  }
+                                </div>
+                              </Button>
+                            ))
+                          }
+                        </div>
+                      </div>
+                      <DropdownButton
+                        noCaret pullRight
+                        style={{
+                          width: '3em',
+                          height: '3em',
+                          marginLeft: '.4em',
+                          // this is to get the icon on center
+                          padding: 0,
+                        }}
+                        title={
+                          <FontAwesome name="bars" />
+                        }
+                        id={`battle-detail-sortie-viewer-battle-${compId}`}
+                      >
+                        <MenuItem
+                          onClick={this.handleClickPlay(si)}
+                        >
+                          {__('BrowseArea.SortieOptions.OpenInReplayer')}
+                        </MenuItem>
+                        <MenuItem
+                          onClick={this.handleCopyToClipboard(si)}
+                        >
+                          {__('BrowseArea.SortieOptions.CopyToClipboard')}
+                        </MenuItem>
+                      </DropdownButton>
+                    </ListGroupItem>
+                  )
+                })
+              }
+            </ListGroup>
+            <Pagination
+              style={{marginBottom: '1em'}}
+              items={pageRange}
+              activePage={activePage}
+              prev
+              next
+              first
+              last
+              ellipsis
+              boundaryLinks
+              maxButtons={5}
+              onSelect={this.handleSelectPage}
+            />
+          </div>
         </div>
       </div>
     )

--- a/views/browse-area/sortie-viewer/index.es
+++ b/views/browse-area/sortie-viewer/index.es
@@ -29,6 +29,7 @@ import { sortieViewerSelector } from '../../selectors'
 import { actionCreators } from '../../store'
 import { convertReplay } from 'lib/convert-replay'
 import { convertToDeckBuilder } from 'lib/deck-builder'
+import { convertToWctf } from 'lib/wctf'
 
 import { PTyp } from '../../ptyp'
 
@@ -124,6 +125,13 @@ class SortieViewerImpl extends PureComponent {
 
   handleCopyDeckBuilderToClipboard = sortieIndexes => async () =>
     clipboard.writeText(JSON.stringify(await convertToDeckBuilder(sortieIndexes)))
+
+  handleViewInWctf = sortieIndexes => async () => {
+    const wData = await convertToWctf(sortieIndexes)
+    const encoded = compressToEncodedURIComponent(JSON.stringify(wData))
+    const rnd = Number(new Date())
+    shell.openExternal(`http://fleet.diablohu.com/fleets/build/?i=${rnd}&d=${encoded}`)
+  }
 
   handleClickSortMethod = method => () =>
     this.modifySortieViewer(
@@ -359,13 +367,11 @@ class SortieViewerImpl extends PureComponent {
                         >
                           {__('BrowseArea.SortieOptions.CopyDeckBuilderToClipboard')}
                         </MenuItem>
-                        {
-                          false && (
-                            <MenuItem>
-                              {__('BrowseArea.SortieOptions.ViewInWctf')}
-                            </MenuItem>
-                          )
-                        }
+                        <MenuItem
+                          onClick={this.handleViewInWctf(si)}
+                        >
+                          {__('BrowseArea.SortieOptions.ViewInWctf')}
+                        </MenuItem>
                       </DropdownButton>
                     </ListGroupItem>
                   )

--- a/views/browse-area/sortie-viewer/index.es
+++ b/views/browse-area/sortie-viewer/index.es
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import { shell } from 'electron'
+import { shell, clipboard } from 'electron'
 import { compressToEncodedURIComponent } from 'lz-string'
 import { createStructuredSelector } from 'reselect'
 import React, { PureComponent } from 'react'
@@ -7,6 +7,7 @@ import { connect } from 'react-redux'
 import {
   ListGroup, ListGroupItem,
   Pagination,
+  DropdownButton, MenuItem,
   Button, ButtonGroup,
 } from 'react-bootstrap'
 import FontAwesome from 'react-fontawesome'
@@ -57,6 +58,8 @@ const rankColors = {
   'E': '#03a9f4',
 }
 
+// TODO: i18n
+
 class SortieViewerImpl extends PureComponent {
   static propTypes = {
     mapIds: PTyp.array.isRequired,
@@ -98,10 +101,15 @@ class SortieViewerImpl extends PureComponent {
 
   handleClickPlay = sortieIndexes => async () => {
     const kc3ReplayData = await convertReplay(sortieIndexes)
-    // console.log(kc3ReplayData)
     const jsonRaw = JSON.stringify(kc3ReplayData)
     const encoded = compressToEncodedURIComponent(jsonRaw)
     shell.openExternal(`${battleReplayerURL}?fromLZString=${encoded}`)
+  }
+
+  handleCopyToClipboard = sortieIndexes => async () => {
+    const kc3ReplayData = await convertReplay(sortieIndexes)
+    const jsonRaw = JSON.stringify(kc3ReplayData)
+    clipboard.writeText(jsonRaw)
   }
 
   handleClickSortMethod = method => () =>
@@ -272,13 +280,31 @@ class SortieViewerImpl extends PureComponent {
                         }
                       </div>
                     </div>
-                    <Button
-                      onClick={this.handleClickPlay(si)}
+                    <DropdownButton
+                      noCaret pullRight
                       style={{
-                        width: '3em', height: '2.5em', marginLeft: '.4em',
-                      }}>
-                      <FontAwesome name="play" />
-                    </Button>
+                        width: '3em',
+                        height: '3em',
+                        marginLeft: '.4em',
+                        // this is to get the icon on center
+                        padding: 0,
+                      }}
+                      title={
+                        <FontAwesome name="bars" />
+                      }
+                      id={`battle-detail-sortie-viewer-battle-${compId}`}
+                    >
+                      <MenuItem
+                        onClick={this.handleClickPlay(si)}
+                      >
+                        Play in KanColle Battle Replayer
+                      </MenuItem>
+                      <MenuItem
+                        onClick={this.handleCopyToClipboard(si)}
+                      >
+                        Copy Replay Data to Clipboard
+                      </MenuItem>
+                    </DropdownButton>
                   </ListGroupItem>
                 )
               })

--- a/views/browse-area/sortie-viewer/index.es
+++ b/views/browse-area/sortie-viewer/index.es
@@ -28,6 +28,7 @@ import {
 import { sortieViewerSelector } from '../../selectors'
 import { actionCreators } from '../../store'
 import { convertReplay } from 'lib/convert-replay'
+import { convertToDeckBuilder } from 'lib/deck-builder'
 
 import { PTyp } from '../../ptyp'
 
@@ -108,11 +109,21 @@ class SortieViewerImpl extends PureComponent {
     shell.openExternal(`${battleReplayerURL}?fromLZString=${encoded}`)
   }
 
-  handleCopyToClipboard = sortieIndexes => async () => {
+  handleCopyReplayToClipboard = sortieIndexes => async () => {
     const kc3ReplayData = await convertReplay(sortieIndexes)
     const jsonRaw = JSON.stringify(kc3ReplayData)
     clipboard.writeText(jsonRaw)
   }
+
+
+  handleViewInDeckBuilder = sortieIndexes => async () => {
+    const encoded =
+      encodeURIComponent(JSON.stringify(await convertToDeckBuilder(sortieIndexes)))
+    shell.openExternal(`http://kancolle-calc.net/deckbuilder.html?predeck=${encoded}`)
+  }
+
+  handleCopyDeckBuilderToClipboard = sortieIndexes => async () =>
+    clipboard.writeText(JSON.stringify(await convertToDeckBuilder(sortieIndexes)))
 
   handleClickSortMethod = method => () =>
     this.modifySortieViewer(
@@ -333,10 +344,28 @@ class SortieViewerImpl extends PureComponent {
                           {__('BrowseArea.SortieOptions.OpenInReplayer')}
                         </MenuItem>
                         <MenuItem
-                          onClick={this.handleCopyToClipboard(si)}
+                          onClick={this.handleCopyReplayToClipboard(si)}
                         >
-                          {__('BrowseArea.SortieOptions.CopyToClipboard')}
+                          {__('BrowseArea.SortieOptions.CopyReplayToClipboard')}
                         </MenuItem>
+                        <MenuItem divider />
+                        <MenuItem
+                          onClick={this.handleViewInDeckBuilder(si)}
+                        >
+                          {__('BrowseArea.SortieOptions.ViewInDeckBuilder')}
+                        </MenuItem>
+                        <MenuItem
+                          onClick={this.handleCopyDeckBuilderToClipboard(si)}
+                        >
+                          {__('BrowseArea.SortieOptions.CopyDeckBuilderToClipboard')}
+                        </MenuItem>
+                        {
+                          false && (
+                            <MenuItem>
+                              {__('BrowseArea.SortieOptions.ViewInWctf')}
+                            </MenuItem>
+                          )
+                        }
                       </DropdownButton>
                     </ListGroupItem>
                   )

--- a/views/browse-area/sortie-viewer/index.es
+++ b/views/browse-area/sortie-viewer/index.es
@@ -98,6 +98,9 @@ class SortieViewerImpl extends PureComponent {
       window.showBattleWithTimestamp(index.id)
   }
 
+  handleOpenReplayer = () =>
+    shell.openExternal(battleReplayerURL)
+
   handleClickPlay = sortieIndexes => async () => {
     const kc3ReplayData = await convertReplay(sortieIndexes)
     const jsonRaw = JSON.stringify(kc3ReplayData)
@@ -149,12 +152,33 @@ class SortieViewerImpl extends PureComponent {
           flex: 1,
         }}
       >
-        <div className="tip">
-          <Markdown
-            source={_.join(__('BrowseArea.SortieTipsMD'), '\n')}
-          />
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            marginBottom: 5,
+          }}
+          className="tip">
+          <div
+            className="markdown"
+            style={{flex: 1}}>
+            <Markdown
+              source={_.join(__('BrowseArea.SortieTipsMD'), '\n')}
+            />
+          </div>
+          <Button
+            style={{
+              flex: 0,
+              marginTop: 0,
+              padding: '5px 10px',
+            }}
+            bsSize="xsmall"
+            onClick={this.handleOpenReplayer}
+          >
+            {__('BrowseArea.SortieOptions.OpenReplayer')}
+          </Button>
         </div>
-        <div style={{display: 'flex'}}>
+        <div style={{display: 'flex', flex: 1}}>
           <div
             style={{
               width: '20%',


### PR DESCRIPTION
Added a new feature that user can copy replay data and paste it into the replayer, in case the generated URL is too long to handle.

Original tips are moved into "Nodes" area, and new tips added for "Sorties" area:

![2017-12-25_200035_3840x1080_scrot](https://user-images.githubusercontent.com/1096354/34344026-65df93a0-e9ae-11e7-9491-521dbf0736fb.jpg)

![2017-12-25_200054_3840x1080_scrot](https://user-images.githubusercontent.com/1096354/34344027-6809fa26-e9ae-11e7-8fbc-4641f35aa1f5.jpg)
