### PR TITLE
ex slot index should not be 'ix' if slot count less than 4

### DIFF
--- a/lib/deck-builder.es
+++ b/lib/deck-builder.es
@@ -89,7 +89,11 @@ const convertToDeckBuilder = async sortieIndexes => {
           itemObj.rf = item.api_level
         if (_.isInteger(item.api_alv))
           itemObj.mas = item.api_alv
-        items.ix = itemObj
+        if (ship.api_slotnum < 4) {
+          items[`i${ship.api_slotnum + 1}`] = itemObj
+        } else {
+          items.ix = itemObj
+        }
       }
 
       const shipObj = {


### PR DESCRIPTION
example:
`{"version":4,"f1":{"s1":{"id":"163","lv":0,"luck":-1,"items":{"i1":{"id":42,"rf":0}}}}}`
`{"version":4,"f1":{"s1":{"id":"402","lv":0,"luck":-1,"items":{"i2":{"id":42,"rf":0}}}}}`
`{"version":4,"f1":{"s1":{"id":"436","lv":0,"luck":-1,"items":{"i3":{"id":42,"rf":0}}}}}`
`{"version":4,"f1":{"s1":{"id":"374","lv":0,"luck":-1,"items":{"i4":{"id":42,"rf":0}}}}}`
