### PR TITLE
Fix white background on generated images

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -334,3 +334,35 @@ table .form-control {
 .replay-render-root .fleet-view.single-fleet > .ship-avatar-container {
   margin: 5px;
 }
+
+.theme-darkly .replay-render-root {
+  background-color: #303030;
+}
+
+.theme-slate .replay-render-root {
+  background-color: #2e3338;
+}
+
+.theme-superhero .replay-render-root {
+  background-color: #546575;
+}
+
+.theme-lumendark .replay-render-root {
+  background-color: #555555;
+}
+
+.theme-paperdark .replay-render-root {
+  background-color: #303030;
+}
+
+.theme-papercyan .replay-render-root {
+  background-color: #222222;
+}
+
+.theme-paperblack .replay-render-root {
+  background-color: #424242;
+}
+
+.theme-darklykai .replay-render-root {
+  background-color: #222222;
+}

--- a/lib/appdata.es
+++ b/lib/appdata.es
@@ -154,4 +154,7 @@ class AppData {
   }
 }
 
-export default new AppData()
+const appDataInst = new AppData()
+window.AppData = appDataInst
+
+export default appDataInst

--- a/views/browse-area/sortie-viewer/replay-generator.es
+++ b/views/browse-area/sortie-viewer/replay-generator.es
@@ -9,7 +9,7 @@ import Markdown from 'react-remarkable'
 import { Avatar } from 'views/components/etc/avatar'
 
 import { showModal } from '../../modal-area'
-import { getMapNodeLetterFuncSelector } from '../../selectors'
+import { getMapNodeLetterFuncSelector, themeSelector } from '../../selectors'
 import { PTyp } from '../../ptyp'
 import { version as pluginVersion } from '../../../package.json'
 import domToImage from 'dom-to-image'
@@ -43,6 +43,7 @@ class ReplayGeneratorImpl extends PureComponent {
   static propTypes = {
     rep: PTyp.object.isRequired,
     getMapNodeLetter: PTyp.func.isRequired,
+    theme: PTyp.string.isRequired,
   }
 
   constructor(props) {
@@ -74,7 +75,6 @@ class ReplayGeneratorImpl extends PureComponent {
           .toPng(
             ref,
             {
-              bgcolor: getComputedStyle($('.modal-body .panel')).backgroundColor,
               width, height,
             })
           .then(dataUrl => {
@@ -100,7 +100,7 @@ class ReplayGeneratorImpl extends PureComponent {
   }
 
   render() {
-    const {rep: {imageInfo, replayData}, getMapNodeLetter} = this.props
+    const {rep: {imageInfo, replayData}, getMapNodeLetter, theme} = this.props
     const {disableSaveImage, comment} = this.state
     const getNodeLetter = getMapNodeLetter(imageInfo.mapId)
     if (imageInfo.fleets.length < 1 || imageInfo.fleets.length > 2) {
@@ -110,6 +110,7 @@ class ReplayGeneratorImpl extends PureComponent {
 
     return (
       <div
+        className={`theme-${theme}`}
         style={{
           display: 'flex',
           flexDirection: 'column',
@@ -321,6 +322,7 @@ class ReplayGeneratorImpl extends PureComponent {
 const ReplayGenerator = connect(
   createStructuredSelector({
     getMapNodeLetter: getMapNodeLetterFuncSelector,
+    theme: themeSelector,
   })
 )(ReplayGeneratorImpl)
 

--- a/views/selectors.es
+++ b/views/selectors.es
@@ -4,6 +4,7 @@ import { mapIdToStr } from 'subtender/kc'
 import {
   extensionSelectorFactory,
   fcdSelector,
+  configSelector as poiConfSelector,
 } from 'views/utils/selectors'
 
 import { initState } from './store'
@@ -11,6 +12,11 @@ import { initState } from './store'
 const extSelector = createSelector(
   extensionSelectorFactory('poi-plugin-battle-detail'),
   ext => _.isEmpty(ext) ? initState : ext)
+
+window.getExt = () => {
+  const {getStore} = window
+  return extSelector(getStore())
+}
 
 const uiSelector = createSelector(
   extSelector,
@@ -48,6 +54,11 @@ const getMapNodeLetterFuncSelector = createSelector(
   })
 )
 
+const themeSelector = createSelector(
+  poiConfSelector,
+  conf => _.get(conf, 'poi.theme', 'paperdark')
+)
+
 export {
   extSelector,
   uiSelector,
@@ -56,4 +67,5 @@ export {
   sortieViewerSelector,
   browseModeSelector,
   getMapNodeLetterFuncSelector,
+  themeSelector,
 }


### PR DESCRIPTION
- when custom background image is used, panel are actually using a transparent background, resulting in generating images of white background.

- fix by hard-coding theme-specific background colors and make sure it's used regardless of customed bg img

- few unrelated devtools: `window.AppData` for getting battle record related functions, `window.getExt` for examining current plugin store more conveniently.