### PR TITLE
fix browser area height overflow

### DIFF
--- a/views/browse-area/index.es
+++ b/views/browse-area/index.es
@@ -153,7 +153,7 @@ class BrowseAreaImpl extends Component {
             </div>
           </Panel.Heading>
           <Panel.Body>
-            <div style={browseMode === 'nodes' ? {} : {display: 'none'}}>
+            <div style={browseMode === 'nodes' ? {overflowY: 'auto'} : {overflowY: 'auto', display: 'none'}}>
               <Grid>
                 <Row>
                   <Col


### PR DESCRIPTION
出击视图的高度样式与节点视图不一致，在窗口高度小于出击视图列表高度时，列表会超出其父节点，付图白框是包裹列表的panel。
![2](https://user-images.githubusercontent.com/8674371/37140131-9ffa35c4-22eb-11e8-82ce-6a36bbbbebaa.png)
