### PR TITLE
add text shadow on battle detail tab

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -2,6 +2,7 @@
   height: 100%;
   overflow: auto;
   display: flex;
+  margin: auto 4px;
 }
 #battle-detail-main .btn-group {
   display: flex;
@@ -364,4 +365,8 @@
 
 #battle-detail-main .theme-darklykai .replay-render-root {
   background-color: #222222;
+}
+
+.bp3-dark #battle-detail-main #main-tabs-pane-0 {
+  text-shadow: 0 1px #000, 1px 0 #000, -1px 0 #000, 0 -1px #000;
 }


### PR DESCRIPTION
添加2条样式：

- 给面板两边增加 4 像素外衬，让他看起来不那么贴着边框
- 给黑暗主题的战斗详情页面的文字添加黑色描边，使他在保存为 png 的时候，贴到<s> NGA </s>
某些论坛时不那么刺眼

添加样式后的效果：

![2](https://user-images.githubusercontent.com/8674371/58999055-74298380-8836-11e9-91d9-28a54cb71ff6.png)