### PR TITLE
Avoid unnecessary writes to index file

### DIFF
--- a/views/index.es
+++ b/views/index.es
@@ -20,6 +20,7 @@ import { PacketCompat, IndexCompat } from '../lib/compat'
 import { initData, actionCreators } from './store'
 import { indexesSelector, uiSelector } from './selectors'
 import { PTyp } from './ptyp'
+import { globalSubscribe, globalUnsubscribe } from './observers'
 
 const { ipc } = window
 const { __ } = window.i18n["poi-plugin-battle-detail"]
@@ -40,20 +41,14 @@ async function handlePacket(newBattle, _curPacket) {
   } = uiSelector(store.getState())
   const newIndex = IndexCompat.getIndex(newBattle, newId)
   store.dispatch(actionCreators.notifyIndex(newId, newIndex))
-  const indexes = indexesSelector(store.getState())
   if (showLast) {
     em.emit('dataupdate', newBattle)
   }
-  /*
-    TODO: perhaps observer can be used after all: we just need to examine the first element.
-    (we'll need a flag to indicate whether initialization is done
-    to avoid writing back during it).
-   */
-  AppData.saveIndex(indexes)
 }
 
 export function pluginDidLoad() {
   initData()
+  globalSubscribe()
   pm.addListener('battle', handlePacket)
   pm.addListener('result', handlePacket)
 }
@@ -61,6 +56,7 @@ export function pluginDidLoad() {
 export function pluginWillUnload() {
   pm.removeListener('battle', handlePacket)
   pm.removeListener('result', handlePacket)
+  globalUnsubscribe()
 }
 
 class MainAreaImpl extends React.Component {

--- a/views/observers.es
+++ b/views/observers.es
@@ -29,7 +29,7 @@ const indexesSaver = observer(
 
 let unsubscribe = null
 
-const globalSubscribe = () => {
+export const globalSubscribe = () => {
   if (unsubscribe !== null) {
     console.warn('expecting "unsubscribe" to be null')
     if (typeof unsubscribe === 'function')
@@ -40,16 +40,11 @@ const globalSubscribe = () => {
   unsubscribe = observe(store, [indexesSaver])
 }
 
-const globalUnsubscribe = () => {
+export const globalUnsubscribe = () => {
   if (typeof unsubscribe !== 'function') {
     console.warn(`unsubscribe is not a function`)
   } else {
     unsubscribe()
     unsubscribe = null
   }
-}
-
-export {
-  globalSubscribe,
-  globalUnsubscribe,
 }

--- a/views/observers.es
+++ b/views/observers.es
@@ -1,0 +1,55 @@
+import _ from 'lodash'
+import { observe, observer } from 'redux-observers'
+import { store } from 'views/create-store'
+import { createSelector } from 'reselect'
+
+import { indexesSelector } from './selectors'
+import { isDataLoaded } from './store/data-maintenance'
+import AppData from '../lib/appdata'
+
+const indexesSaver = observer(
+  /*
+    observing first element of indexes is sufficient to detect changes,
+    as new index is always inserted in front, one at a time.
+   */
+  createSelector(
+    indexesSelector,
+    indexes => indexes[0]
+  ),
+  (_dispatch, cur, prev) => {
+    if (!isDataLoaded()) {
+      return
+    }
+    if (!_.isEqual(cur, prev)) {
+      const indexes = indexesSelector(store.getState())
+      AppData.saveIndex(indexes)
+    }
+  }
+)
+
+let unsubscribe = null
+
+const globalSubscribe = () => {
+  if (unsubscribe !== null) {
+    console.warn('expecting "unsubscribe" to be null')
+    if (typeof unsubscribe === 'function')
+      unsubscribe()
+    unsubscribe = null
+  }
+
+  unsubscribe = observe(store, [indexesSaver])
+}
+
+const globalUnsubscribe = () => {
+  if (typeof unsubscribe !== 'function') {
+    console.warn(`unsubscribe is not a function`)
+  } else {
+    unsubscribe()
+    unsubscribe = null
+  }
+}
+
+export {
+  globalSubscribe,
+  globalUnsubscribe,
+}

--- a/views/store/data-maintenance.es
+++ b/views/store/data-maintenance.es
@@ -10,13 +10,17 @@ import { sleep } from '../utils'
 import { showModal, hideModal } from '../modal-area'
 import { indexesSelector, uiSelector } from '../selectors'
 import { boundActionCreators } from './ext-root'
-import { groupBattleIndexes } from './battle-groupper'
 
 const { getStore } = window
 const { __ } = window.i18n["poi-plugin-battle-detail"]
 
 const INDEXES_LOAD_INTERVAL = 500
 const INDEXES_LOAD_NUMBER = 500
+
+// a flag that will be set to true once data are loaded
+let dataLoaded = false
+
+const isDataLoaded = () => dataLoaded
 
 const createIndex = async (list) => {
   let eta = new Date(Date.now() + list.length / INDEXES_LOAD_NUMBER * INDEXES_LOAD_INTERVAL)
@@ -71,7 +75,7 @@ const updateIndex = async (indexes) => {
   boundActionCreators.atomicReplaceIndexes(indexes)
 }
 
-export const initData =  async () => {
+const initData =  async () => {
   // Load index from disk
   let indexes = await AppData.loadIndex()
   for (let line of indexes) {
@@ -85,7 +89,10 @@ export const initData =  async () => {
       await AppData.listBattle(),
       indexes.map((x) => x.id),
     )
-    if (diff.length === 0) return
+    if (diff.length === 0) {
+      dataLoaded = true
+      return
+    }
     const newIndex = await createIndex(diff)
     const currentIndexes = indexesSelector(getStore())
     indexes = newIndex.concat(currentIndexes || [])
@@ -107,5 +114,10 @@ export const initData =  async () => {
       ],
     })
   }
+  dataLoaded = true
 }
 
+export {
+  initData,
+  isDataLoaded,
+}

--- a/views/store/data-maintenance.es
+++ b/views/store/data-maintenance.es
@@ -20,7 +20,7 @@ const INDEXES_LOAD_NUMBER = 500
 // a flag that will be set to true once data are loaded
 let dataLoaded = false
 
-const isDataLoaded = () => dataLoaded
+export const isDataLoaded = () => dataLoaded
 
 const createIndex = async (list) => {
   let eta = new Date(Date.now() + list.length / INDEXES_LOAD_NUMBER * INDEXES_LOAD_INTERVAL)
@@ -75,7 +75,7 @@ const updateIndex = async (indexes) => {
   boundActionCreators.atomicReplaceIndexes(indexes)
 }
 
-const initData =  async () => {
+export const initData =  async () => {
   // Load index from disk
   let indexes = await AppData.loadIndex()
   for (let line of indexes) {
@@ -115,9 +115,4 @@ const initData =  async () => {
     })
   }
   dataLoaded = true
-}
-
-export {
-  initData,
-  isDataLoaded,
 }


### PR DESCRIPTION
Slight improvement while I'm at it: use observer to trigger index save so that it only saves when actual index update happens - should cut index save frequency by half:

- before: save when entering battle & save at battle result
- after: save when entering battle, then save again only if `_.isEqual` test fails (this rarely happens)

Manually tested.