### PR TITLE
chore: migrate react-i18next v10

### DIFF
--- a/views/browse-area/sortie-viewer/index.es
+++ b/views/browse-area/sortie-viewer/index.es
@@ -16,7 +16,7 @@ import {
   modifyObject,
   mergeMapStateToProps,
 } from 'subtender'
-import { translate } from 'react-i18next'
+import { withTranslation } from 'react-i18next'
 
 import {
   sortieIndexesDomainSelector,
@@ -70,7 +70,7 @@ const rankColors = {
   'E': '#03a9f4',
 }
 
-@translate('poi-plugin-battle-detail')
+@withTranslation('poi-plugin-battle-detail')
 class SortieViewerImpl extends PureComponent {
   static propTypes = {
     // connected

--- a/views/browse-area/sortie-viewer/replay-generator.es
+++ b/views/browse-area/sortie-viewer/replay-generator.es
@@ -7,7 +7,7 @@ import { Panel, Button, FormControl } from 'react-bootstrap'
 import { remote, shell } from 'electron'
 import Markdown from 'react-remarkable'
 import { Avatar } from 'views/components/etc/avatar'
-import { translate } from 'react-i18next'
+import { withTranslation } from 'react-i18next'
 
 import { showModal } from '../../modal-area'
 import { themeSelector } from '../../selectors'
@@ -41,7 +41,7 @@ const { __ } = window.i18n["poi-plugin-battle-detail"]
 const battleReplayerURL = 'https://kc3kai.github.io/kancolle-replay/battleplayer.html'
 const imagesPath = join(__dirname, '..','..','..','assets','images')
 
-@translate('poi-plugin-battle-detail')
+@withTranslation('poi-plugin-battle-detail')
 class ReplayGeneratorImpl extends PureComponent {
   static propTypes = {
     rep: PTyp.object.isRequired,


### PR DESCRIPTION
I thought it would be better to make it work even if the main "poi/views/polyfills/react-i18next.es" does not exist.

I am thinking of modifying and testing other plugins as well. If the team plans to have an abstraction layer for I18n in the future, this was my afterthought.

I replaced all the v9 to v10 changes listed in the URL below, and tested the Japanese display.

Migrating v9 to v10 - react-i18next documentation
https://react.i18next.com/latest/migrating-v9-to-v10
