### PR TITLE
fix: Adjust usage and UI details

### DIFF
--- a/assets/main.css
+++ b/assets/main.css
@@ -47,7 +47,7 @@
 #battle-detail-main .bp5-tab-list .bp5-tab,
 #battle-detail-main .bp6-tab-list .bp6-tab {
   flex: 1;
-  text-align: center;
+  justify-content: center;
 }
 
 /* Detail area rows */

--- a/views/browse-area/index.tsx
+++ b/views/browse-area/index.tsx
@@ -118,7 +118,7 @@ const BrowseAreaImpl: React.FC<BrowseAreaProps> = ({
             <span>{__('Tip_Akashic1_Part2')}</span>
           </div>
           <form onSubmit={onClickFilter}>
-            <HTMLTable striped interactive className="browse-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <HTMLTable striped interactive bordered className="browse-table" style={{ width: '100%', borderCollapse: 'collapse' }}>
               <thead>
                 <tr>
                   <th>#</th>

--- a/views/browse-area/u-pagination.tsx
+++ b/views/browse-area/u-pagination.tsx
@@ -41,7 +41,7 @@ export const UPagination: React.FC<UPaginationProps> = ({ currentPage, totalPage
   if (totalPages > 1) addPage(totalPages)
 
   return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 4, ...style }}>
+    <div style={{ display: 'flex', alignItems: 'center', gap: 4, justifyContent: 'center', marginTop: 16, ...style }}>
       <Button
         disabled={currentPage <= 1}
         onClick={() => onChange(currentPage - 1)}

--- a/views/overview-area.tsx
+++ b/views/overview-area.tsx
@@ -16,7 +16,7 @@ const { __ } = window.i18n['poi-plugin-battle-detail']
 type PoiAirBasePlane = RawLBAC['api_plane_info'][number] & { poi_slot?: RawSlotItem | null }
 
 const OverviewArea: React.FC<{ simulator: Simulator }> = ({ simulator }) => {
-  const [expanded, setExpanded] = useState(true)
+  const [expanded, setExpanded] = useState(false)
 
   return (
     <div id="overview-area">
@@ -166,7 +166,7 @@ interface ItemViewProps {
 }
 
 const ItemView: React.FC<ItemViewProps> = ({ item, extra, label, warn }) => {
-  if (!item) return <div />
+  if (!item || Object.keys(item).length === 0) return <div />
   const raw = item
   const mst = getStore(['const', '$equips', String(item.api_slotitem_id)]) || {}
   const data = {
@@ -175,16 +175,17 @@ const ItemView: React.FC<ItemViewProps> = ({ item, extra, label, warn }) => {
   }
 
   const apiType3: number | undefined = data.api_type?.[3]
+  const itemName: string = `${getShipName(data)}`
   return (
     <div className="item-view">
-      <div className="item-info">
+      <div className="item-info" title={itemName}>
         <span className="item-icon">
           <SlotitemIcon slotitemId={apiType3 ?? 0} />
           {(label != null && (extra || (apiType3 != null && equipIsAircraft(data)))) ? (
             <span className={`number ${warn ? 'text-warning' : ''}`}>{label}</span>
           ) : null}
         </span>
-        <span className="item-name">{`${getShipName(data)}`}</span>
+        <span className="item-name">{itemName}</span>
       </div>
       <div className="item-attr">
         <span className="alv">


### PR DESCRIPTION
- **将“战斗”和“浏览”两个 Tab 文本居中**
- **为出击列表添加边框**
- **页码组件居中展示**
- **战斗概览默认收起**
- **不显示空的装备栏**
- **悬停显示完整的装备名称**